### PR TITLE
Add node v0.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - "0.10"
   - "0.9"
   - "0.8"

--- a/tasks/mocha-hack.js
+++ b/tasks/mocha-hack.js
@@ -8,7 +8,9 @@ var mochaReporterBase = require('mocha/lib/reporters/base');
 
 module.exports = function(grunt) {
   grunt.registerMultiTask('mocha-hack', 'Run tests with mocha', function() {
-    var paths = this.filesSrc.map(path.resolve);
+    var paths = this.filesSrc.map(function (file) {
+        return path.resolve(file);
+    });
     // Retrieve options from the grunt task.
     var options = this.options();
     var gruntDone = this.async();


### PR DESCRIPTION
The node v0.10 path module will throw exception when argument not string:

```
Warning: Arguments to path.resolve must be strings Use --force to continue.
```

The map method will give (item, index, list) three arguments, the index will be a number, list is the list array. In node v0.8, ignore the non-string argument, but node v0.10 not.
