### PR TITLE
Add ability to configure full stack trace

### DIFF
--- a/tasks/mocha-hack.js
+++ b/tasks/mocha-hack.js
@@ -36,6 +36,7 @@ module.exports = function(grunt) {
     var reporter = new mocha._reporter(runner);
     runner.ignoreLeaks = options.ignoreLeaks;
     runner.asyncOnly = options.asyncOnly;
+    runner.fullStackTrace = options.fullStackTrace;
     if (options.grep) runner.grep(options.grep, options.invert);
     if (options.globals) runner.globals(options.globals);
     if (options.growl) mocha._growl(runner, reporter);


### PR DESCRIPTION
As of mocha 2.2.3 stack traces will be empty for assertion errors without the ability to configure. With this, in your task options you can specify `fullStackTrace: true` to get full stack traces back.

https://github.com/mochajs/mocha/compare/2.2.1...2.2.3#diff-aa849a970cef551664c12f04a4209f6fR429
